### PR TITLE
feat(SW): Implement low mem variant

### DIFF
--- a/internal/smithwaterman/smithwaterman.go
+++ b/internal/smithwaterman/smithwaterman.go
@@ -99,3 +99,77 @@ func index(x, y, width int) int {
 func index2coord(index, width int) (int, int) {
 	return index / width, index % width
 }
+
+// Low mem variants
+func FindLocalAlignmentLowMem(query, target string) (string, string, int) {
+	width := len(query) + 1
+	height := len(target) + 1
+	wrapping_height := len(query) * (1 + (MATCH_SCORE / GAP_PENALTY))
+
+	score := make([]int, width*wrapping_height)
+
+	best_query_result := ""
+	best_target_result := ""
+
+	max_score := 0
+
+	for y := 1; y < height; y++ {
+		for x := 1; x < width; x++ {
+			sub_score := MATCH_SCORE
+
+			if query[x-1] != target[y-1] {
+				sub_score = -MISMATCH_PENALTY
+			}
+
+			new_score := max(0,
+				score[index_wrapping(x-1, y-1, width, wrapping_height)]+sub_score,
+				score[index_wrapping(x-1, y, width, wrapping_height)]-GAP_PENALTY,
+				score[index_wrapping(x, y-1, width, wrapping_height)]-GAP_PENALTY)
+
+			score[index_wrapping(x, y, width, wrapping_height)] = new_score
+
+			if max_score < new_score {
+				max_score = new_score
+				var queryResult, targetResult strings.Builder
+				traceback_wrapping(score, query, target, x, y, width, wrapping_height, &queryResult, &targetResult)
+				best_query_result = queryResult.String()
+				best_target_result = targetResult.String()
+			}
+		}
+	}
+
+	return best_query_result, best_target_result, max_score
+}
+
+func index_wrapping(x, y, width, wrapping_height int) int {
+	return x + (y%wrapping_height)*width
+}
+
+func traceback_wrapping(matrix []int, query, target string, x, y, width, wrapping_height int, queryResult, targetResult *strings.Builder) {
+	if x == 0 || y == 0 {
+		return
+	}
+
+	matchScore := MATCH_SCORE
+	if query[x-1] != target[y-1] {
+		matchScore = -MISMATCH_PENALTY
+	}
+
+	// TODO: Evaluate what is more important in the case of multiple paths
+	score := matrix[index_wrapping(x, y, width, wrapping_height)]
+	if score == 0 {
+		return
+	} else if score == matrix[index_wrapping(x-1, y-1, width, wrapping_height)]+matchScore {
+		traceback_wrapping(matrix, query, target, x-1, y-1, width, wrapping_height, queryResult, targetResult)
+		queryResult.WriteByte(query[x-1])
+		targetResult.WriteByte(target[y-1])
+	} else if score == matrix[index_wrapping(x-1, y, width, wrapping_height)]-GAP_PENALTY {
+		traceback_wrapping(matrix, query, target, x-1, y, width, wrapping_height, queryResult, targetResult)
+		queryResult.WriteByte(query[x-1])
+		targetResult.WriteRune('-')
+	} else {
+		traceback_wrapping(matrix, query, target, x, y-1, width, wrapping_height, queryResult, targetResult)
+		queryResult.WriteRune('-')
+		targetResult.WriteByte(target[y-1])
+	}
+}


### PR DESCRIPTION
This implementation uses a 2D circular buffer as the underlying datastructure. We can theoretically determine that the maximum length of a traceback can at most be:

```
wrapping_height =  |query| * (1 + (MATCH_SCORE / GAP_PENALTY))
```

by using a circular buffer we the height can be wrapping height. Considering the query is often *a lot* smaller than the target this will drastically reduce the size of the matrix.

A quick calculation arises at the following size of the matrix
```
matrix_size = width * wrapping_height * size of integer
```

In our case:
```
matrix_size = 331 * ( 330 * (1 + (2 / 1))) * 16 bit = 655kB
```

There is a downside to this algorithm however. As soon as we find a new best score we have to do the traceback right away because otherwise we could overwrite the data on the next line.
Because of this there is a branch instruction inside the hot loop which will come with some performance cost. There are micro-optimizations possible, but maybe not right now.

Also all index calculations now use a mod instruction which are not necessary in the original algorithm.

In conclusion, use this algorithm when memory might be constraint. Maybe worker nodes can specify a upper limit of resources that can be used and if a job requires more than that using the original method we can switch to this implementation.